### PR TITLE
Fix team picture on mobile

### DIFF
--- a/_sass/_classy.scss
+++ b/_sass/_classy.scss
@@ -47,6 +47,7 @@ aside {
   padding-top: $nav-height;
   
   .hero-container {
+    background: black;
     // background-image: url("../assets/team_pic.jpg");
     height: 100%;
     //background-size: 100% auto;
@@ -54,7 +55,10 @@ aside {
     background-repeat: no-repeat;
     background-size: cover;
     position: relative;
-    opacity: .8;
+    @media (max-width: 900px) {
+      background-position: top;
+      background-size: contain;
+    }
   }
 }
 


### PR DESCRIPTION
I just added a media query for the index.html background picture, and then set the background color to black. Since you were using opacity and a white background to lighten the pic, I just created an 80% opacity copy of the image in photoshop, which I (don't think) I can update via the CDN, so here it is, just replace the current image with this on merge and it should be all good! 

![team_pic_80p](https://user-images.githubusercontent.com/1200038/28838039-d494cadc-76a3-11e7-90ca-8bb72735b1ec.jpg)
